### PR TITLE
New exit condition

### DIFF
--- a/software/lizards/src/main.cpp
+++ b/software/lizards/src/main.cpp
@@ -147,7 +147,7 @@ void loop()
                     // Serial.println(i);
                 }
             }
-        } while ((measured_num < NGATES) && (current_millis - start_millis <= TIMEOUT_MILLIS));
+        } while ((i < NGATES) && (current_millis - start_millis <= TIMEOUT_MILLIS));
 
         // Display measured times
         for (uint8_t i = 0; i < (NGATES); i++) {

--- a/software/lizards/src/main.cpp
+++ b/software/lizards/src/main.cpp
@@ -147,7 +147,8 @@ void loop()
                     // Serial.println(i);
                 }
             }
-        } while ((i < NGATES) && (current_millis - start_millis <= TIMEOUT_MILLIS));
+        } while ((measured_num < NGATES) && (current_millis - start_millis <= TIMEOUT_MILLIS) && (measured_status[NGATES-1]));
+        // } while ((i < NGATES) && (current_millis - start_millis <= TIMEOUT_MILLIS));
 
         // Display measured times
         for (uint8_t i = 0; i < (NGATES); i++) {


### PR DESCRIPTION
Stop measurement after the last gate is triggered. Do not wait for all gates to get triggered, as animals might jump over some gates and then return to them later.